### PR TITLE
kubernetes: null pointer exception when secret does not exist

### DIFF
--- a/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesService.java
+++ b/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesService.java
@@ -36,13 +36,17 @@ public class KubernetesService {
         return getSecretByVault(resource) != null;
     }
 
-    void createSecret(Vault resource, VaultSecret vaultSecret) {
+    private Secret newSecretInstance(Vault resource, VaultSecret vaultSecret){
         Secret secret = new Secret();
         secret.setType(vaultSecret.getType());
         secret.setMetadata(metaData(resource.getMetadata(), vaultSecret.getCompare()));
         secret.setData(vaultSecret.getData());
 
-        client.secrets().inNamespace(resource.getMetadata().getNamespace()).create(secret);
+        return secret;
+    }
+
+    void createSecret(Vault resource, VaultSecret vaultSecret) {
+        client.secrets().inNamespace(resource.getMetadata().getNamespace()).create(newSecretInstance(resource, vaultSecret));
 
         log.info("Created secret for vault resource {} in namespace {}", resource.getMetadata().getName(), resource.getMetadata().getNamespace());
     }
@@ -54,7 +58,13 @@ public class KubernetesService {
 
     void modifySecret(Vault resource, VaultSecret vaultSecret) {
         Resource<Secret, DoneableSecret> secretDoneableSecretResource = client.secrets().inNamespace(resource.getMetadata().getNamespace()).withName(resource.getMetadata().getName());
-        Secret secret = secretDoneableSecretResource.get();
+        Secret secret;
+        try {
+            secret = secretDoneableSecretResource.get();
+        } catch (NullPointerException e) {
+            secret = newSecretInstance(resource, vaultSecret);
+        }
+
         secret.setType(vaultSecret.getType());
         updateAnnotations(secret, vaultSecret.getCompare());
         secret.setData(vaultSecret.getData());


### PR DESCRIPTION
Hello 

When Kubernetes secret not found I got error: 

```
2019-03-20 11:12:11.012 ERROR 8 --- [TaskScheduler-1] o.s.s.s.TaskUtils$LoggingErrorHandler : Unexpected error occurred in scheduled task.
java.lang.NullPointerException: null
2019-03-20 11:12:10.978 INFO 8 --- [TaskScheduler-1] d.k.v.k.scheduler.ScheduledRefresh : Start refresh of secret...
```