### PR TITLE
WIP: App Role Authentication

### DIFF
--- a/src/main/java/de/koudingspawn/vault/vault/VaultConfiguration.java
+++ b/src/main/java/de/koudingspawn/vault/vault/VaultConfiguration.java
@@ -5,14 +5,15 @@ import org.springframework.beans.factory.config.ServiceLocatorFactoryBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.vault.authentication.ClientAuthentication;
-import org.springframework.vault.authentication.KubernetesAuthentication;
-import org.springframework.vault.authentication.KubernetesAuthenticationOptions;
-import org.springframework.vault.authentication.TokenAuthentication;
+import org.springframework.vault.authentication.*;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.config.AbstractVaultConfiguration;
+import org.springframework.vault.support.VaultToken;
 
 import java.net.URI;
+
+import static org.springframework.vault.authentication.AppRoleAuthenticationOptions.RoleId.provided;
+import static org.springframework.vault.authentication.AppRoleAuthenticationOptions.SecretId.wrapped;
 
 @Configuration
 public class VaultConfiguration {
@@ -73,6 +74,71 @@ public class VaultConfiguration {
                     KubernetesAuthenticationOptions.builder().role(role).build();
 
             return new KubernetesAuthentication(options, restOperations());
+        }
+    }
+
+    @Configuration
+    @ConditionalOnProperty(name = "kubernetes.vault.auth", havingValue = "appRole")
+    class VaultAppRoleAuthentication extends AbstractVaultConfiguration {
+        private final String vaultUrl;
+        private final String roleId;
+        private final String vaultToken;
+
+        VaultAppRoleAuthentication(@Value("${kubernetes.vault.url}") String vaultUrl,
+                                   @Value("${kubernetes.vault.token}") String vaultToken,
+                                   @Value("${kubernetes.vault.roleId}") String roleId) {
+            this.vaultUrl = vaultUrl;
+            this.roleId = roleId;
+            this.vaultToken = vaultToken;
+        }
+
+        @Override
+        public VaultEndpoint vaultEndpoint() {
+            return VaultEndpoint.from(getVaultUrlWithoutPath(vaultUrl));
+        }
+
+        @Override
+        public ClientAuthentication clientAuthentication() {
+            AppRoleAuthenticationOptions options = AppRoleAuthenticationOptions.builder()
+                    .roleId(provided(roleId))
+                    .secretId(wrapped(VaultToken.of(vaultToken)))
+                    .build();
+            return new AppRoleAuthentication(options, restOperations());
+        }
+    }
+
+    @Configuration
+    @ConditionalOnProperty(name = "kubernetes.vault.auth", havingValue = "appRolePull")
+    class VaultAppRolePullAuthentication extends AbstractVaultConfiguration {
+
+        private final String vaultUrl;
+        private final String vaultToken;
+        private final String role;
+
+        VaultAppRolePullAuthentication(@Value("${kubernetes.vault.url}") String vaultUrl,
+                                       @Value("${kubernetes.vault.token}") String vaultToken,
+                                       @Value("${kubernetes.vault.role}") String role) {
+            this.vaultUrl = vaultUrl;
+            this.vaultToken = vaultToken;
+            this.role = role;
+        }
+
+        @Override
+        public VaultEndpoint vaultEndpoint() {
+            return VaultEndpoint.from(getVaultUrlWithoutPath(vaultUrl));
+        }
+
+        @Override
+        public ClientAuthentication clientAuthentication() {
+            VaultToken initialToken = VaultToken.of(vaultToken);
+
+            AppRoleAuthenticationOptions options = AppRoleAuthenticationOptions.builder()
+                    .appRole(role)
+                    .roleId(AppRoleAuthenticationOptions.RoleId.pull(initialToken))
+                    .secretId(AppRoleAuthenticationOptions.SecretId.pull(initialToken))
+                    .build();
+
+            return new AppRoleAuthentication(options, restOperations());
         }
     }
 


### PR DESCRIPTION
Work in Progress to implement #4 App Role Authentication

Please see the following Docker Image to test App Role Authentication: daspawnw/vault-crd:1.3.0-beta

For App Role Authentication the following methods are available:

## appRole

required environment variables:

KUBERNETES_VAULT_AUTH = 'appRole'
KUBERNETES_VAULT_URL = 'https://.../v1/
KUBERNETES_VAULT_ROLEID = ''            <-- Required role-id
KUBERNETES_VAULT_TOKEN = 'token'              <-- Required for wrapped SecretId

## appRolePull

required environment variables:

KUBERNETES_VAULT_AUTH = 'appRolePull'
KUBERNETES_VAULT_URL = 'https://.../v1/
KUBERNETES_VAULT_TOKEN = ''         <---- Initial Token for pull
KUBERNETES_VAULT_ROLE =  ''          <---- app role name