### PR TITLE
Add support for custom auth backend path

### DIFF
--- a/src/main/java/de/koudingspawn/vault/vault/VaultConfiguration.java
+++ b/src/main/java/de/koudingspawn/vault/vault/VaultConfiguration.java
@@ -55,11 +55,19 @@ public class VaultConfiguration {
 
         private final String vaultUrl;
         private final String role;
+        private final String path;
 
         VaultServiceAccountConnection(@Value("${kubernetes.vault.url}") String vaultUrl,
-                                      @Value("${kubernetes.vault.role}") String role) {
+                                      @Value("${kubernetes.vault.role}") String role,
+                                      @Value("${kubernetes.vault.path}") String path) {
             this.vaultUrl = vaultUrl;
             this.role = role;
+
+            if (!path.equals("")) {
+                this.path = path;
+            } else {
+                this.path = KubernetesAuthenticationOptions.DEFAULT_KUBERNETES_AUTHENTICATION_PATH;
+            }
         }
 
         @Override
@@ -70,7 +78,7 @@ public class VaultConfiguration {
         @Override
         public ClientAuthentication clientAuthentication() {
             KubernetesAuthenticationOptions options =
-                    KubernetesAuthenticationOptions.builder().role(role).build();
+                    KubernetesAuthenticationOptions.builder().path(path).role(role).build();
 
             return new KubernetesAuthentication(options, restOperations());
         }

--- a/src/main/java/de/koudingspawn/vault/vault/VaultConfiguration.java
+++ b/src/main/java/de/koudingspawn/vault/vault/VaultConfiguration.java
@@ -59,15 +59,10 @@ public class VaultConfiguration {
 
         VaultServiceAccountConnection(@Value("${kubernetes.vault.url}") String vaultUrl,
                                       @Value("${kubernetes.vault.role}") String role,
-                                      @Value("${kubernetes.vault.path}") String path) {
+                                      @Value("${kubernetes.vault.path:kubernetes}") String path) {
             this.vaultUrl = vaultUrl;
             this.role = role;
-
-            if (!path.equals("")) {
-                this.path = path;
-            } else {
-                this.path = KubernetesAuthenticationOptions.DEFAULT_KUBERNETES_AUTHENTICATION_PATH;
-            }
+            this.path = path;
         }
 
         @Override


### PR DESCRIPTION
Current implementation only supports one kubernetes backend in vault, registered in default path such as this:
```
vault auth enable kubernetes
#aka
vault auth enable -path="kubernetes" kubernetes
```

To support multiple kubernetes clusters in one vault, multiple auth backends can be configured as follows:
```
vault auth enable -path="kubernetes/cluster-one" kubernetes
vault auth enable -path="kubernetes/cluster-two" kubernetes
```

This pull request allows specifying an additional `KUBERNETES_VAULT_PATH` env variable which defaults to `kubernetes`.

To configure the example clusters, one would set `KUBERNETES_VAULT_PATH=kubernetes/cluster-one` and `KUBERNETES_VAULT_PATH=kubernetes/cluster-two` respectively.