### PR TITLE
Use CRD name to register custom Kind

### DIFF
--- a/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesConnection.java
+++ b/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesConnection.java
@@ -12,6 +12,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.internal.KubernetesDeserializer;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -44,7 +45,8 @@ public class KubernetesConnection {
                 = client.customResourceDefinitions().withName(crdName);
 
         // Hack for bug in Kubernetes-Client for CRDs https://github.com/fabric8io/kubernetes-client/issues/1099
-        KubernetesDeserializer.registerCustomKind("koudingspawn.de/v1#Vault", Vault.class);
+        String kind = StringUtils.substringAfter(crdName, ".") + "/v1#Vault";
+        KubernetesDeserializer.registerCustomKind(kind, Vault.class);
 
         CustomResourceDefinition customResourceDefinition = crdResource.get();
         if (customResourceDefinition == null) {


### PR DESCRIPTION
Hello,

I encountered an issue when deploying Vault-CRD with a custom CRD name (by overriding the variable kubernetes.crd.name)

The fix proposal extracts the custom kind from the CRD name.

Best regards