### PR TITLE
Propagate annotations and labels from CRDs to secrets

### DIFF
--- a/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesService.java
+++ b/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesService.java
@@ -87,8 +87,10 @@ public class KubernetesService {
         ObjectMeta meta = new ObjectMeta();
         meta.setNamespace(resource.getNamespace());
         meta.setName(resource.getName());
+        meta.setLabels(resource.getLabels());
 
         HashMap<String, String> annotations = new HashMap<>();
+        annotations.putAll(resource.getAnnotations());
         annotations.put(crdName + LAST_UPDATE_ANNOTATION, LocalDateTime.now().toString());
         annotations.put(crdName + COMPARE_ANNOTATION, compare);
         meta.setAnnotations(annotations);


### PR DESCRIPTION
Hello,

My use case requires to be able to manage annotations and labels on the Kubernetes secrets.
This enhancement proposes to propagate the labels and annotations of the CRDs to the secrets (it could be covered by a feature flag if this assumption is not applicable for all users).

As I'm not able to run the unit tests on my local environnement, it may not currently handle all cases.
However, it seems to be working fine on my Kubernetes cluster for a new secret.

Best regards