### PR TITLE
Ability To Restrict Syncing Secrets To Whitelisted Namespaces

### DIFF
--- a/src/main/java/de/koudingspawn/vault/kubernetes/EventHandler.java
+++ b/src/main/java/de/koudingspawn/vault/kubernetes/EventHandler.java
@@ -4,6 +4,10 @@ import de.koudingspawn.vault.crd.Vault;
 import de.koudingspawn.vault.vault.VaultSecret;
 import de.koudingspawn.vault.vault.VaultService;
 import de.koudingspawn.vault.vault.communication.SecretNotAccessibleException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map.Entry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -21,10 +25,28 @@ public class EventHandler {
         this.kubernetesService = kubernetesService;
     }
 
+    protected void checkSecretWhitelist (VaultSecret secretContent, Vault resource) throws SecretNotAccessibleException {
+        for (Entry<String,String> entry : secretContent.getData().entrySet ()) {
+            if (entry.getKey().equals ("x-vault-crd-namespaces")) {
+                String decodedValue = new String(Base64.getDecoder().decode(entry.getValue()));
+                List<String> allowedNamespaces = Arrays.asList(decodedValue.split(","));
+                if (!allowedNamespaces.contains(resource.getMetadata().getNamespace())) {
+                    kubernetesService.deleteSecret(resource.getMetadata());
+                    String message = String.format(
+                        "Namespace is not whitelisted for secret '%s'",
+                        resource.getMetadata().getName()
+                    );
+                    throw new SecretNotAccessibleException(message);
+                }
+            }
+        }
+    }
+
     public void addHandler(Vault resource) {
         if (!kubernetesService.exists(resource)) {
             try {
                 VaultSecret secretContent = vaultService.generateSecret(resource);
+                checkSecretWhitelist(secretContent, resource);
                 kubernetesService.createSecret(resource, secretContent);
             } catch (SecretNotAccessibleException e) {
                 log.error("Failed to generate secret for vault resource {} in namespace {} failed with exception:",
@@ -41,6 +63,7 @@ public class EventHandler {
 
         try {
             VaultSecret secretContent = vaultService.generateSecret(resource);
+            checkSecretWhitelist(secretContent, resource);
             kubernetesService.modifySecret(resource, secretContent);
         } catch (SecretNotAccessibleException e) {
             log.error("Failed to modify secret for vault resource {} in namespace {} failed with exception:",


### PR DESCRIPTION
### About

This PR was created to allow people to define a namespace whitelist inside a secret definition in Vault. This could come in handy if people (like myself) want to use a vault-crd deployment across the cluster but want to restrict the ability to sync certain secrets by binding them to a list of whitelisted namespaces that they can be synced to. This whitelist will be defined in a secret as a property entry with the key being equal to `x-vault-crd-namespaces` and the value equaling a comma separated list of namespaces.

Checking the whitelist happens on the `add` event as well as the `modify` event. This means that if a whitelist is added to an already synced secret, then it will do one of the following:

- If namespace that secret is synced to is in whitelist, then secret is updated
- Otherwise, secret is deleted

### Simple Example

Consider the following secret definition in Vault:

|           Key          |        Value        |
|:----------------------:|:-------------------:|
|           foo          |         bar         |
| x-vault-crd-namespaces | default,kube-system |

Without the effects of this PR, this secret would be synced to any namespace on the cluster. With this PR, this secret could only be synced to the `default` and `kube-system` namespace.

The whitelist can be one value or multiple separated by the `,` character. Whitespace matters so `default,kube-system` is not the same as `default, kube-system`. Empty values between commas should just be ignored but are still valid, i.e. `default,,kube-system,`.

### Demo

For the lifetime of this PR, a hosted docker image can be pulled and used to try this PR out. It lives on [null93/vault-crd:latest](https://hub.docker.com/repository/docker/null93/vault-crd). Helm command for convenience:

```shell
$ helm upgrade --install vault-crd-demo vault-crd/vault-crd \
    --set vaultCRD.repository=null93/vault-crd-test \
    --set vaultCRD.tag=latest \
    --set vaultCRD.pullPolicy=Always \
    --set vaultCRD.vaultUrl=https://vault-server/v1/ \
    --set vaultCRD.vaultAuth=serviceAccount \
    --set vaultCRD.vaultRole=vault-auth
```

### Backward-Compatibility

If no entry for `x-vault-crd-namespaces` is found in a secret, then it is synced as usual. For this reason this implementation is backwards compatible.

### Possible Problems

Not sure if this will affect how PKI & Certs are synced.

### Credits

The syntax and original inspiration for this implementation was _borrowed_ from [drone-vault](https://docs.drone.io/secret/external/vault).