### PR TITLE
add ownerReference to secrets

### DIFF
--- a/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesService.java
+++ b/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesService.java
@@ -104,7 +104,7 @@ public class KubernetesService {
         boolean blockOwnerDeletion = false;
         boolean controller = true;
         OwnerReference owner = new OwnerReference(
-          "koudingspawn.de/v1",
+          crdName + "/v1",
           blockOwnerDeletion,
           controller,
           "Vault",

--- a/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesService.java
+++ b/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesService.java
@@ -4,6 +4,7 @@ import de.koudingspawn.vault.crd.Vault;
 import de.koudingspawn.vault.vault.VaultSecret;
 import io.fabric8.kubernetes.api.model.DoneableSecret;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -13,6 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -98,6 +100,21 @@ public class KubernetesService {
         annotations.put(crdName + LAST_UPDATE_ANNOTATION, LocalDateTime.now().toString());
         annotations.put(crdName + COMPARE_ANNOTATION, compare);
         meta.setAnnotations(annotations);
+
+        boolean blockOwnerDeletion = false;
+        boolean controller = true;
+        OwnerReference owner = new OwnerReference(
+          "koudingspawn.de/v1",
+          blockOwnerDeletion,
+          controller,
+          "Vault",
+          resource.getName(),
+          resource.getUid()
+        );
+        ArrayList<OwnerReference> owners = new ArrayList<>();
+        owners.add(owner);
+        meta.setOwnerReferences(owners);
+
         return meta;
     }
 


### PR DESCRIPTION
This allows tools like ArgoCD to notice that the secrets exist and expose them in the UI, consistent with the way deployments, daemonsets, and so on are handled.

![image](https://user-images.githubusercontent.com/58439537/93349902-ad082480-f7fd-11ea-8231-8eeacc294052.png)
