### PR TITLE
update all metadata when updating a secret

### DIFF
--- a/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesService.java
+++ b/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesService.java
@@ -69,7 +69,7 @@ public class KubernetesService {
         }
 
         secret.setType(vaultSecret.getType());
-        updateAnnotations(secret, vaultSecret.getCompare());
+        secret.setMetadata(metaData(resource.getMetadata(), vaultSecret.getCompare()));
         secret.setData(vaultSecret.getData());
 
         secretDoneableSecretResource.createOrReplace(secret);
@@ -99,16 +99,5 @@ public class KubernetesService {
         annotations.put(crdName + COMPARE_ANNOTATION, compare);
         meta.setAnnotations(annotations);
         return meta;
-    }
-
-
-    private void updateAnnotations(Secret secret, String compare) {
-        if (secret.getMetadata().getAnnotations() == null) {
-            secret.getMetadata().setAnnotations(new HashMap<>());
-        }
-
-        Map<String, String> annotations = secret.getMetadata().getAnnotations();
-        annotations.put(crdName + LAST_UPDATE_ANNOTATION, LocalDateTime.now().toString());
-        annotations.put(crdName + COMPARE_ANNOTATION, compare);
     }
 }


### PR DESCRIPTION
I noticed that the labels (and ownerReferences) are only propagated when a secret is created, so you cannot update the values on an existing secret.  While all-out replacing the metadata is a little assertive, I think it's consistent with gitops best-practices and other kubernetes controllers.