### PR TITLE
copy explicitly named labels from vault-crd to secret

### DIFF
--- a/src/main/java/de/koudingspawn/vault/Constants.java
+++ b/src/main/java/de/koudingspawn/vault/Constants.java
@@ -4,4 +4,5 @@ public class Constants {
     public static String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm'Z'";
     public static String COMPARE_ANNOTATION = "/compare";
     public static String LAST_UPDATE_ANNOTATION = "/lastUpdated";
+    public static String COPY_LABELS_ANNOTATION = "/copyLabels";
 }

--- a/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesService.java
+++ b/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesService.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import static de.koudingspawn.vault.Constants.COMPARE_ANNOTATION;
 import static de.koudingspawn.vault.Constants.LAST_UPDATE_ANNOTATION;
+import static de.koudingspawn.vault.Constants.COPY_LABELS_ANNOTATION;
 
 @Component
 public class KubernetesService {
@@ -87,13 +88,21 @@ public class KubernetesService {
         ObjectMeta meta = new ObjectMeta();
         meta.setNamespace(resource.getNamespace());
         meta.setName(resource.getName());
-        if (resource.getLabels() != null) {
-            meta.setLabels(resource.getLabels());
-        }
-
         HashMap<String, String> annotations = new HashMap<>();
         if (resource.getAnnotations() != null) {
             annotations.putAll(resource.getAnnotations());
+            Map<String, String> labels = resource.getLabels();
+            if (labels != null) {
+                String[] labelNames = annotations.getOrDefault(crdName + COPY_LABELS_ANNOTATION, "").split(",");
+                HashMap<String, String> secretLabels = new HashMap<>();
+                for (String labelName : labelNames) {
+                  String value = labels.get(labelName);
+                  if (value != null) {
+                    secretLabels.put(labelName, value);
+                  }
+                }
+                meta.setLabels(secretLabels);
+            }
         }
         annotations.put(crdName + LAST_UPDATE_ANNOTATION, LocalDateTime.now().toString());
         annotations.put(crdName + COMPARE_ANNOTATION, compare);


### PR DESCRIPTION
This change requires that the vault-crd explicitly list labels to copy rather than implicitly copying them.  There's a label added by ArgoCD that implies that the secret was managed by ArgoCD which creates a synchronization difference.  ArgoCD will happily remove the secret, and then moments later vault-crd will add it back, ad-infinitum.