### PR TITLE
Upgrade to java 17 for cgroup2 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcr.io/distroless/java:11-nonroot AS SECURITY
-FROM openjdk:11 AS BUILD
+FROM gcr.io/distroless/java17:nonroot AS SECURITY
+FROM openjdk:17 AS BUILD
 
 COPY . /opt
 WORKDIR /opt
@@ -7,14 +7,14 @@ RUN ./mvnw clean install -DskipTests
 
 ENV JAVA_RANDOM="file:/dev/./urandom"
 
-COPY --from=SECURITY /etc/java-11-openjdk/security/java.security /java.security
+COPY --from=SECURITY /etc/java-17-openjdk/security/java.security /java.security
 RUN echo "networkaddress.cache.ttl=60" >> /java.security
 RUN sed -i -e "s@^securerandom.source=.*@securerandom.source=${JAVA_RANDOM}@" /java.security
 
-FROM gcr.io/distroless/java:11-nonroot
+FROM gcr.io/distroless/java17:nonroot
 
 COPY --from=BUILD /opt/target/vault-crd.jar /opt/vault-crd.jar
-COPY --from=BUILD /java.security /etc/java-11-openjdk/security/java.security
+COPY --from=BUILD /java.security /etc/java-17-openjdk/security/java.security
 
 ENTRYPOINT ["/usr/bin/java", "-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts", "-Djavax.net.ssl.trustStorePassword=changeit", "-Djavax.net.ssl.trustStoreType=jks"]
 CMD ["-jar", "/opt/vault-crd.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 		<fabric8.version>5.9.0</fabric8.version>
 		<logback.version>1.2.8</logback.version>
 		<log4j2.version>2.16.0</log4j2.version>


### PR DESCRIPTION
Signed-off-by: Tomas Kohout <tomas.kohout1995@gmail.com>

Hi @DaspawnW ,

I've created this pull request so vault-crd works flawlessly also on cgroups2. 

Cheers
Tomas