### PR TITLE
Update dependencies of spring, kubernetes client and some more

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.1.3</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<fabric8.version>6.4.0</fabric8.version>
+		<fabric8.version>6.8.1</fabric8.version>
 	</properties>
 
 	<dependencies>
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>8.0.0.Final</version>
+			<version>8.0.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.springframework.vault</groupId>
 			<artifactId>spring-vault-core</artifactId>
-			<version>3.0.0</version>
+			<version>3.0.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -57,13 +57,13 @@
 		<dependency>
 			<groupId>com.github.ben-manes.caffeine</groupId>
 			<artifactId>caffeine</artifactId>
-			<version>3.1.2</version>
+			<version>3.1.8</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.hubspot.jinjava</groupId>
 			<artifactId>jinjava</artifactId>
-			<version>2.6.0</version>
+			<version>2.7.1</version>
 		</dependency>
 
 
@@ -75,7 +75,7 @@
 		<dependency>
 			<groupId>com.github.tomakehurst</groupId>
 			<artifactId>wiremock</artifactId>
-			<version>3.0.0-beta-2</version>
+			<version>3.0.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesConnection.java
+++ b/src/main/java/de/koudingspawn/vault/kubernetes/KubernetesConnection.java
@@ -3,11 +3,12 @@ package de.koudingspawn.vault.kubernetes;
 import de.koudingspawn.vault.crd.Vault;
 import de.koudingspawn.vault.crd.VaultList;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
-import io.fabric8.kubernetes.client.*;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.internal.KubernetesDeserializer;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,15 +39,8 @@ public class KubernetesConnection {
     @Bean
     public MixedOperation<Vault, VaultList, Resource<Vault>> customResource(
             KubernetesClient client,
-            KubernetesDeserializer kubernetesDeserializer,
             @Value("${kubernetes.crd.name}") String crdName) {
         Resource<CustomResourceDefinition> crdResource = client.apiextensions().v1().customResourceDefinitions().withName(crdName);
-
-        // Hack for bug in Kubernetes-Client for CRDs https://github.com/fabric8io/kubernetes-client/issues/1099
-        String kind = "Vault";
-        String version = StringUtils.substringAfter(crdName, ".") + "/v1";
-        kubernetesDeserializer.registerCustomKind(version, kind, Vault.class);
-
         CustomResourceDefinition customResourceDefinition = crdResource.get();
         if (customResourceDefinition == null) {
             log.error("Please first apply custom resource definition and then restart vault-crd");
@@ -55,10 +49,4 @@ public class KubernetesConnection {
 
         return client.resources(Vault.class, VaultList.class);
     }
-
-    @Bean
-    public KubernetesDeserializer kubernetesDeserializer() {
-        return new KubernetesDeserializer();
-    }
-
 }

--- a/src/test/java/de/koudingspawn/vault/admissionreview/AdmissionReviewTest.java
+++ b/src/test/java/de/koudingspawn/vault/admissionreview/AdmissionReviewTest.java
@@ -51,8 +51,10 @@ public class AdmissionReviewTest {
 
     @Before
     public void setup() {
-        String kind = StringUtils.substringAfter("vault.koudingspawn.de", ".") + "/v1#Vault";
-        KubernetesDeserializer.registerCustomKind(kind, Vault.class);
+        KubernetesDeserializer kubernetesDeserializer = new KubernetesDeserializer();
+        String version = StringUtils.substringAfter("vault.koudingspawn.de", ".") + "/v1";
+        String kind = "Vault";
+        kubernetesDeserializer.registerCustomKind(version, kind, Vault.class);
     }
 
     @Test

--- a/src/test/java/de/koudingspawn/vault/admissionreview/AdmissionReviewTest.java
+++ b/src/test/java/de/koudingspawn/vault/admissionreview/AdmissionReviewTest.java
@@ -7,9 +7,6 @@ import de.koudingspawn.vault.vault.VaultService;
 import de.koudingspawn.vault.vault.communication.SecretNotAccessibleException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.internal.KubernetesDeserializer;
-import org.apache.commons.lang3.StringUtils;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -48,14 +45,6 @@ public class AdmissionReviewTest {
 
     @Autowired
     private MockMvc mvc;
-
-    @Before
-    public void setup() {
-        KubernetesDeserializer kubernetesDeserializer = new KubernetesDeserializer();
-        String version = StringUtils.substringAfter("vault.koudingspawn.de", ".") + "/v1";
-        String kind = "Vault";
-        kubernetesDeserializer.registerCustomKind(version, kind, Vault.class);
-    }
 
     @Test
     public void shouldFailWithInvalidRequest() throws Exception {

--- a/src/test/java/de/koudingspawn/vault/kubernetes/KubernetesServiceTest.java
+++ b/src/test/java/de/koudingspawn/vault/kubernetes/KubernetesServiceTest.java
@@ -4,7 +4,6 @@ import de.koudingspawn.vault.crd.Vault;
 import de.koudingspawn.vault.kubernetes.cache.SecretCache;
 import de.koudingspawn.vault.vault.VaultSecret;
 import io.fabric8.kubernetes.api.model.*;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.junit.After;


### PR DESCRIPTION
We updated the dependency of spring, kubernetes client and some more

Also we removed the hack regarding a small bug in kubernetes client which seems to be solved.

Original ticket regarding the hack:
https://github.com/fabric8io/kubernetes-client/issues/1099

Related ticket which solves the issue:
https://github.com/fabric8io/kubernetes-client/issues/1285

>> Looking at this again - from the original motivation and typical usage with fabric8 it no longer needs to be moved. If you are using the dsl, there's no need to manually call registerCustomKind.

In fact the hack is not longer available the static function for `registerCustomKind` is gone. (it's now part of the instance, but as mentioned in the quote manually setting should not be needed)

Unit / Integration tests are running. We also tested it locally by using kubernetes with 'kind'.